### PR TITLE
fix: typo in import

### DIFF
--- a/src/wildcard.tsx
+++ b/src/wildcard.tsx
@@ -18,7 +18,7 @@ import userTableAdapter from "./localStorageAdapter"
 import thunk from 'redux-thunk';
 import { initializeActions } from './core/actions'
 import { getFinalRecords, getFinalAttributes } from './core/getFinalTable'
-import { TableAdapterMiddleware } from './TableAdapterMiddleware'
+import { TableAdapterMiddleware } from './tableAdapterMiddleware'
 
 // todo: move this out of this file
 const connectRedux = (component, actions) => {


### PR DESCRIPTION
Hey, I think it worked for you before perhaps because you're on OSX, where the filesystem is case insensitive. On Linux, the build fails.