### PR TITLE
[WIP] Ajax filter fixes

### DIFF
--- a/src/wildcard-ajax.js
+++ b/src/wildcard-ajax.js
@@ -1,49 +1,46 @@
+let isFirefox = navigator.userAgent.indexOf("Firefox") != -1;
+
 function onError(error) {
     console.error(`Error: ${error}`);
 }
 
+
 function listener(details) {
-    if(navigator.userAgent.indexOf("Firefox") != -1 )
+    let filter = browser.webRequest.filterResponseData(details.requestId);
+
+    let data = [];
+    filter.ondata = event =>
     {
-        let filter = browser.webRequest.filterResponseData(details.requestId);
+        data.push(event.data);
+        filter.write(event.data);
+    };
 
-        let data = [];
-        filter.ondata = event =>
+    let handleEvent = async event =>
+    {
+        let blob = new Blob(data, {type: 'application/json'});
+        let bstr = await blob.text();
+        let obj = undefined;
+        try
         {
-            data.push(event.data);
-            filter.write(event.data);
-        };
-
-        filter.onstop = async event =>
+            obj = JSON.parse(bstr);
+        } catch
         {
-            let blob = new Blob(data, {type: 'application/json'});
-            let bstr = await blob.text();
-            let obj = undefined;
-            try
+            return;
+        }
+        browser.tabs.sendMessage(
+            details.tabId,
             {
-                obj = JSON.parse(bstr);
-            } catch
-            {
+                url: details.url,
+                data: obj
+            }
+        ).catch(onError)
+    };
 
-            }
-            if (obj !== undefined)
-            {
-                browser.tabs.sendMessage(
-                    details.tabId,
-                    {
-                        url: details.url,
-                        data: obj
-                    }
-                ).catch(
-                    onError
-                )
-            }
-            filter.close();
-        };
-    }
+    filter.onstop = async event =>
+        handleEvent(event).finally(() => filter.close());
 }
 
-if(navigator.userAgent.indexOf("Firefox") != -1 )
+if (isFirefox)
 {
     browser.webRequest.onBeforeRequest.addListener(
         listener,

--- a/src/wildcard-ajax.js
+++ b/src/wildcard-ajax.js
@@ -47,7 +47,7 @@ if(navigator.userAgent.indexOf("Firefox") != -1 )
 {
     browser.webRequest.onBeforeRequest.addListener(
         listener,
-        {urls: ["<all_urls>"]},
+        {urls: ["<all_urls>"], types: ["main_frame"]},
         ["blocking"]
     );
 }


### PR DESCRIPTION
Tagging @TylerMillis as the original author.

- first commit: adds "main_frame" scope. Without it, some pages (e.g. https://hn.algolia.com) aren't loading at all. I haven't managed to figure out why exactly, but the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter#Examples) suggests using it anyway, so perhaps it makes sense regardless?

- second commit -- mainly added `finally` clause, so filters don't leak in case of exception, but also didn some minor cleanup, hope you don't mind!

Also wondering, what's the reason to use "blocking"? It works without it (at least the uber eats page), and the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest#addListener_syntax) says it's used for cancels or redirects (makes sense).

P.S. oh, also, I guess `urls: ["<all_urls>"]` is a bit too broad? I guess this would be good to fix later.
