### PR TITLE
Ajax filter fixes

### DIFF
--- a/src/wildcard-ajax.js
+++ b/src/wildcard-ajax.js
@@ -47,7 +47,7 @@ if(navigator.userAgent.indexOf("Firefox") != -1 )
 {
     browser.webRequest.onBeforeRequest.addListener(
         listener,
-        {urls: ["<all_urls>"]},
+        {urls: ["<all_urls>"], types: ["main_frame", "xmlhttprequest"]},
         ["blocking"]
     );
 }


### PR DESCRIPTION
Tagging @TylerMillis as the original author.

- first commit: adds main_frame and xmlhttprequest scopes. Without it, some pages (e.g. https://hn.algolia.com) aren't loading at all. I haven't managed to figure out why exactly, but the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/StreamFilter#Examples) suggest limiting the scope anyway, so perhaps it makes sense.

- second commit -- mainly added `finally` clause, so filters don't leak in case of exception, but also didn some minor cleanup, hope you don't mind!

Also wondering, what's the reason to use "blocking"? It works without it (at least the uber eats page), and the [documentation](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/webRequest/onBeforeRequest#addListener_syntax) says it's used for cancels or redirects (makes sense).

P.S. oh, also, I guess `urls: ["<all_urls>"]` is a bit too broad? I guess this would be good to fix later.
