### PR TITLE
show context menu for adding/toggling columns

### DIFF
--- a/src/site_adapters/domScrapingBase.ts
+++ b/src/site_adapters/domScrapingBase.ts
@@ -313,11 +313,11 @@ export function createDomScrapingAdapter(config:ScrapingAdapterConfig):TableAdap
   }
 
   const addAttribute = () => {
-    return Promise.reject("Can't add attributes to site adapter")
+    return Promise.reject("Attributes can only be added to user tables.")
   }
 
   const toggleVisibility = (colName) => {
-    return Promise.reject("Can't hide/show attributes in WildCard")
+    return Promise.reject("Visibility can only be toggled for user tables.")
   }
 
   // todo: support highlighting individual attributes

--- a/src/ui/WcPanel.tsx
+++ b/src/ui/WcPanel.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useState } from "react";
 import { HotTable } from '@handsontable/react';
 import "handsontable/dist/handsontable.full.css";
+import "./overrides.css";
 
 import styled from 'styled-components'
 
@@ -98,8 +99,11 @@ const WcPanel = ({ records, attributes, query, actions }) => {
     contextMenu: {
       items: {
         "insert_user_attribute": {
-          name: 'Insert new column',
+          name: 'Insert new user column',
           callback: function(key, selection, clickEvent) {
+            // TODO: For now, new columns always get added to the user table.
+            // Eventually, do we want to allow adding to the main site table?
+            // Perhaps that'd be a way of extending scrapers using formulas...
             actions.addAttribute("user");
           }
         },
@@ -112,12 +116,18 @@ const WcPanel = ({ records, attributes, query, actions }) => {
         },
         "toggle_column_visibility":{
           name: 'Toggle visibility',
+          disabled: () => {
+            // only allow toggling visibility on user table
+            const colIndex = getHotInstance().getSelectedLast()[1]
+            const attribute = attributes[colIndex]
+
+            return attribute.tableId !== "user"
+          },
           callback: function(key, selection, clickEvent) {
-            var allCols = attributes.map(attr => attr.name);
-            var idx = selection[0].start.col;
+            const attribute = attributes[selection[0].start.col];
 
             // NOTE! idx assumes that id is hidden.
-            actions.toggleVisibility("user", allCols[idx]);
+            actions.toggleVisibility(attribute.tableId, attribute.name);
           }
         }
       }

--- a/src/ui/overrides.css
+++ b/src/ui/overrides.css
@@ -1,0 +1,6 @@
+/* In WcPanel.tsx, we set the z-index of our table to 2200 (to put it above original site content)
+   So, we also need to tell the context menu to be visible above the table.
+   We do this by overridding the default HoT CSS. */
+.htContextMenu:not(.htGhostTable) {
+  z-index: 2300;
+}


### PR DESCRIPTION
The context menu was hidden underneath the rest of the table,
making it impossible to add/toggle visibility for columns.
This fixes the z-index issue and fully supports
adding/toggling columns for the user table.

Got partway through renaming columns but didn't finish;
that will need further refactoring to assign IDs to
attributes separately from names.