### PR TITLE
Initial stub: DOM formulas

### DIFF
--- a/src/formula.ts
+++ b/src/formula.ts
@@ -105,6 +105,10 @@ const functions = {
   },
   "Round": function(x) {
     return promisify(Math.round(x))
+  },
+  "GetAttribute": function(el, attrName) {
+    // todo: error handling here?
+    return promisify(el.getAttribute(attrName))
   }
 }
 

--- a/src/site_adapters/domScrapingBase.ts
+++ b/src/site_adapters/domScrapingBase.ts
@@ -283,7 +283,9 @@ export function createDomScrapingAdapter(config:ScrapingAdapterConfig):TableAdap
           extractedValue = value.value;
         }
         else if (value instanceof HTMLElement) {
-          extractedValue = value.textContent;
+          // Return DOM Elements as-is to the table;
+          // we'll extract text contents at display time.
+          extractedValue = value;
         } else {
           extractedValue = value;
         }

--- a/src/site_adapters/hackerNews.ts
+++ b/src/site_adapters/hackerNews.ts
@@ -16,7 +16,7 @@ const HNAdapter = createDomScrapingAdapter({
   attributes: [
     { name: "id", type: "text", hidden: true },
     { name: "rank", type: "numeric" },
-    { name: "title", type: "text" },
+    { name: "title", type: "element", editable: true },
     { name: "link", type: "text" },
     { name: "points", type: "numeric" },
     { name: "user", type: "text" },

--- a/src/ui/WcPanel.tsx
+++ b/src/ui/WcPanel.tsx
@@ -9,20 +9,23 @@ import styled from 'styled-components'
 import { Record, Attribute } from '../core/types'
 import Handsontable from "handsontable";
 import { FormulaEditor } from '../ui/cell_editors/formulaEditor'
+import mapValues from 'lodash/mapValues'
 
 const marketplaceUrl = "https://wildcard-marketplace.herokuapp.com";
 
 function formatRecordsForHot(records:Array<Record>) {
   return records.map(record => ({
     id: record.id,
-    ...record.values
+    ...mapValues(record.values, v => v instanceof HTMLElement ? v.textContent : v)
   }))
 }
 
 function formatAttributesForHot(attributes:Array<Attribute>) {
   return attributes.map(attribute => ({
     data: attribute.name,
-    type: attribute.type,
+
+    // If it's an "element" attribute, just render it as text
+    type: attribute.type === "element" ? "text" : attribute.type,
     readOnly: !attribute.editable,
     editor: attribute.editor
   }))
@@ -157,6 +160,8 @@ const WcPanel = ({ records, attributes, query, actions, adapter, creatingAdapter
     colHeaders: attributes.map(attr => {
       if(attr.formula) {
         return `<span class="formula-header">${attr.name}</span>`
+      } else if(attr.type === "element") {
+        return `<span class="element-header">${attr.name}</span>`
       } else {
         return `<span class="data-header">${attr.name}</span>`
       }
@@ -335,7 +340,16 @@ const WcPanel = ({ records, attributes, query, actions, adapter, creatingAdapter
     actions.selectRecord(record.id, prop)
 
     setActiveCell({ record, attribute })
-    const activeCellValue = (attribute.formula || record.values[attribute.name] || "")
+
+    let activeCellValue
+
+    if (attribute.formula) {
+      activeCellValue = attribute.formula
+    } else if (attribute.type === "element") {
+      activeCellValue = record.values[attribute.name].outerHTML
+    } else {
+      activeCellValue = record.values[attribute.name] || ""
+    }
     setActiveCellValue(activeCellValue)
   }
 

--- a/src/ui/overrides.css
+++ b/src/ui/overrides.css
@@ -13,3 +13,12 @@ th span.formula-header:before {
   font-size: 12px;
   color: #888;
 }
+
+th span.element-header:before {
+  content: "</>";
+  margin-right: 10px;
+  margin-left: -10px;
+  font-style: italic;
+  font-size: 12px;
+  color: #888;
+}


### PR DESCRIPTION
This is a PR to serve as an initial demonstration of how we might put DOM elements in table cells in Wildcard. Not meant as a full implementation yet.

[Demo video](https://www.loom.com/share/3bdc25e35d504f4eb5ea0ded3c4d34de)

## Code changes

It's a pretty minimal code change. Here's the overview.

There's a DOM Scraping Base adapter that's responsible for returning data from the page to the main WC system.

Previously, if the user-provided scraping code returned a DOM element, the Scraping Base adapter would extract the text contents and return that to WC as the cell value. Now, instead, we just return the DOM element directly.

We then have to deal with that new type of value downstream in the UI layer. Currently, here's what we do:

- for the table, extract and display text content
- for the formula bar, extract the outerHTML and display that
- add a little decoration to the column header

I've also added a new attribute type "element" to reflect the fact that a scraper can return an element directly.

## Open questions

In general we need to consider a holistic UX that makes sense to users. Some specific questions:

- Should "element" be a distinct datatype like "text" or "number"? Or should it live alongside those datatypes -- i.e., I can specify that this is a number column, but it also includes an underlying DOM element
- Relatedly -- should DOM elements live in separate cells from their displayed output, or show up together as one cell? In this version they're combined into one because the text output shows up on the DOM element cell directly
- What other formulas to add?